### PR TITLE
fix:  Fix xui local startup failure

### DIFF
--- a/compose/xui.yml
+++ b/compose/xui.yml
@@ -20,6 +20,7 @@ services:
       SERVICES_PAYMENTS_URL: http://wiremock:8080
 
       SERVICES_EM_ANNO_API: http://ccd-api-gateway:3453
+      REDISCLOUD_URL: fake
 
       FEATURE_APP_INSIGHTS_ENABLED: "false"
       FEATURE_SECURE_COOKIE_ENABLED: "false"


### PR DESCRIPTION
### Change description ###
This PR fixes the local failure of xui at start up with latest image release yesterday.

`xui_1                             | Error: Configuration property "secrets.rpx.webapp-redis-connection-string" is not defined`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
