### PR TITLE
feat: added missing healthcheck endpoint (CMC-NA)

### DIFF
--- a/mocks/wiremock/mappings/fees-register/health.json
+++ b/mocks/wiremock/mappings/fees-register/health.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/health"
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"status\": \"UP\"}"
+  }
+}


### PR DESCRIPTION
### Change description ###

unspec-service is logging an error because of missing healthcheck endpoint on wiremock

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
