### PR TITLE
fix: updated docmosis site to Free Trial Tornado

### DIFF
--- a/compose/docmosis.yml
+++ b/compose/docmosis.yml
@@ -9,7 +9,7 @@ services:
     environment:
       # not supported in current version of Tornado
       - DOCMOSIS_KEY
-      - DOCMOSIS_SITE="Free Trial License"
+      - DOCMOSIS_SITE="Free Trial Tornado"
     volumes:
       - ../../docker/docmosis/templates:/home/docmosis/templates:rw
     ports:


### PR DESCRIPTION
### Change description ###

DOCMOSIS_SITE was changed for newest licences from Free Trial Licence to Free Trial Tornado, required for new licences to work.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
