### PR TITLE
feat: added failed responses to payments wiremock

### DIFF
--- a/mocks/wiremock/__files/payment/accountOnHoldResponse.json
+++ b/mocks/wiremock/__files/payment/accountOnHoldResponse.json
@@ -1,0 +1,15 @@
+{
+  "reference": "RC-1604-3318-7433-7915",
+  "date_created": "2020-11-02T15:44:34.340+0000",
+  "status": "Failed",
+  "payment_group_reference": "2020-1604331872578",
+  "status_histories": [
+    {
+      "status": "failed",
+      "error_code": "CA-E0004",
+      "error_message": "Your account is deleted",
+      "date_created": "2020-11-02T15:44:34.347+0000",
+      "date_updated": "2020-11-02T15:44:34.347+0000"
+    }
+  ]
+}

--- a/mocks/wiremock/__files/payment/successResponse.json
+++ b/mocks/wiremock/__files/payment/successResponse.json
@@ -1,11 +1,11 @@
 {
   "reference": "RC-1234-1234-1234-1234",
   "date_created": "2020-02-20T20:20:20.222+0000",
-  "status": "Pending",
+  "status": "Success",
   "payment_group_reference": "2020-1582230020222",
   "status_histories": [
     {
-      "status": "pending",
+      "status": "success",
       "date_created": "2020-02-20T20:20:20.222+0000",
       "date_updated": "2020-02-20T20:20:20.222+0000"
     }

--- a/mocks/wiremock/mappings/payments/failedNotFound.json
+++ b/mocks/wiremock/mappings/payments/failedNotFound.json
@@ -1,0 +1,22 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "POST",
+        "urlPath": "/credit-account-payments",
+        "bodyPatterns": [
+          {
+            "contains": "\"PBA0079005\""
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": "Account information could not be found"
+      }
+    }
+  ]
+}

--- a/mocks/wiremock/mappings/payments/failedOnHold.json
+++ b/mocks/wiremock/mappings/payments/failedOnHold.json
@@ -1,0 +1,22 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "POST",
+        "urlPath": "/credit-account-payments",
+        "bodyPatterns": [
+          {
+            "contains": "\"PBA0078094\""
+          }
+        ]
+      },
+      "response": {
+        "status": 403,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "payment/accountOnHoldResponse.json"
+      }
+    }
+  ]
+}

--- a/mocks/wiremock/mappings/payments/successful.json
+++ b/mocks/wiremock/mappings/payments/successful.json
@@ -3,14 +3,19 @@
     {
       "request": {
         "method": "POST",
-        "urlPath": "/credit-account-payments"
+        "urlPath": "/credit-account-payments",
+        "bodyPatterns": [
+          {
+            "contains": "\"PBA0077597\""
+          }
+        ]
       },
       "response": {
         "status": 201,
         "headers": {
           "Content-Type": "application/json"
         },
-        "bodyFileName": "payment/paymentResponse.json"
+        "bodyFileName": "payment/successResponse.json"
       }
     }
   ]


### PR DESCRIPTION
### Change description ###

Added different wiremock responses to reflect actual Payments API behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
