### PR TITLE
FIX: CMC-1359: XUI have added 2 new environment variables that are require…

### DIFF
--- a/compose/xui.yml
+++ b/compose/xui.yml
@@ -37,6 +37,9 @@ services:
 
       JURISDICTIONS: "CIVIL"
 
+      SYSTEM_USER_NAME: "dummy"
+      SYSTEM_USER_PASSWORD: "dummy"
+
     ports:
       - 3333:3000
     depends_on:


### PR DESCRIPTION
…d for their latest docker image to work in a local setup

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1359


### Change description ###
Latest xui docker image requires 2 new environment variable, otherwise the container fails to start for a local setup


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
